### PR TITLE
Python3 compatibility changes: message needs to be converted from Uni…

### DIFF
--- a/GDAX/AuthenticatedClient.py
+++ b/GDAX/AuthenticatedClient.py
@@ -142,9 +142,10 @@ class GdaxAuth(AuthBase):
     def __call__(self, request):
         timestamp = str(time.time())
         message = timestamp + request.method + request.path_url + (request.body or '')
+        message = message.encode('ascii')
         hmac_key = base64.b64decode(self.secret_key)
         signature = hmac.new(hmac_key, message, hashlib.sha256)
-        signature_b64 = signature.digest().encode('base64').rstrip('\n')
+        signature_b64 = base64.b64encode(signature.digest())
         request.headers.update({
             'CB-ACCESS-SIGN': signature_b64,
             'CB-ACCESS-TIMESTAMP': timestamp,


### PR DESCRIPTION
Just got around to playing w/ the AuthenticatedClient. The hmac code needed a couple fixes to make it Python3 compatible.