### PR TITLE
Support multiple products via websockets stream

### DIFF
--- a/GDAX/WebsocketClient.py
+++ b/GDAX/WebsocketClient.py
@@ -20,7 +20,11 @@ class WebsocketClient():
     def setup(self):
         self.open()
         self.ws = create_connection(self.url)
-        subParams = json.dumps({"type": "subscribe", "product_id": self.product_id})
+        if type(self.product_id) is list:
+            #product_ids - plural for multiple products
+            subParams = json.dumps({"type": "subscribe", "product_ids": self.product_id})
+        else:
+            subParams = json.dumps({"type": "subscribe", "product_id": self.product_id})
         self.ws.send(subParams)
         self.listen()
 

--- a/README.md
+++ b/README.md
@@ -193,10 +193,21 @@ authClient.withdraw(withdrawParams)
 
 ### WebsocketClient
 If you would like to receive real-time market updates, you must subscribe to the [websocket feed](https://docs.gdax.com/#websocket-feed).
+
+#### Subscribe to a single product
 ```python
 import GDAX
 # Paramters are optional
 wsClient = GDAX.WebsocketClient(ws_url="wss://ws-feed.gdax.com", product_id="BTC-USD")
+# Do other stuff...
+wsClient.close()
+```
+
+#### Subscribe to a multiple product
+```python
+import GDAX
+# Paramters are optional
+wsClient = GDAX.WebsocketClient(ws_url="wss://ws-feed.gdax.com", product_id=["BTC-USD", "ETH-USD"])
 # Do other stuff...
 wsClient.close()
 ```

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ wsClient = GDAX.WebsocketClient(ws_url="wss://ws-feed.gdax.com", product_id="BTC
 wsClient.close()
 ```
 
-#### Subscribe to a multiple product
+#### Subscribe to multiple products
 ```python
 import GDAX
 # Paramters are optional


### PR DESCRIPTION
Currently you are only able to subscribe to a single product via the web socket stream

The GDAX API supports [subscribing multiple currencies](https://docs.gdax.com/#subscribe).

This PR maintains the legacy functionality while adding support for multiple currencies 
